### PR TITLE
[WIP] Add activationCommands to defer loading the package

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,9 @@
   "engines": {
     "atom": ">=1.13.0 <2.0.0"
   },
+  "activationCommands": {
+    "atom-text-editor": ["ide-haskell-hoogle:show-doc-for-symbol", "ide-haskell-hoogle:show-web-doc-for-symbol"]
+  },
   "dependencies": {
     "atom-highlight": "^0.3.0",
     "atom-select-list": "^0.2.0",


### PR DESCRIPTION
It seems ide-haskell-hoogle adds quite a bit of startup time when opening atom (around 300-400ms on my laptop), which is quite unfortunate.

I tried adding activation commands to defer the loading, but for some reason it doesn't quite work. The hoogle command appears in the `cmd + shift + p` box, but disappears after trying to use it.

Is anyone aware of what might cause this?